### PR TITLE
Add runnable snippet for Google Places API and data shape example

### DIFF
--- a/components/backend/research/data-sources/google-places/api_snippet.py
+++ b/components/backend/research/data-sources/google-places/api_snippet.py
@@ -1,7 +1,5 @@
-# FIXME don't commit
 import json
 import os
-from pprint import pprint
 from typing import Any
 
 import requests

--- a/components/backend/research/data-sources/google-places/api_snippet.py
+++ b/components/backend/research/data-sources/google-places/api_snippet.py
@@ -1,0 +1,83 @@
+# FIXME don't commit
+import json
+import os
+from pprint import pprint
+from typing import Any
+
+import requests
+
+API_KEY = os.getenv("GOOGLE_PLACES_API_KEY")
+assert API_KEY, "GOOGLE_PLACES_API_KEY env var is not set"
+
+YEREVAN_CENTER = (40.177585, 44.512534)
+RADIUS = 500  # meters
+URL = f"https://places.googleapis.com/v1/places:searchNearby"
+
+DEFAULT_MIN_RATING = 4.0
+DEFAULT_MAX_RESULT_COUNT = 10
+
+
+def fetch_places(
+    center: tuple[float, float],
+    radius: float,
+    field_mask: list[str],
+    min_rating: float = DEFAULT_MIN_RATING,
+    max_result_count: int = DEFAULT_MAX_RESULT_COUNT,
+    included_types: list[str] | None = None,
+    excluded_types: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    if included_types and excluded_types:
+        msg = "Either `included_types` or `excluded_types` must be specified, not both"
+        raise ValueError(msg)
+
+    field_mask_str = ",".join(field_mask)
+    headers = {
+        "Content-Type": "application/json",
+        "X-Goog-Api-Key": API_KEY,
+        "X-Goog-FieldMask": field_mask_str,
+    }
+
+    request_body = {
+        "maxResultCount": max_result_count,
+        "locationRestriction": {
+            "circle": {
+                "center": {
+                    "latitude": center[0],
+                    "longitude": center[1],
+                },
+                "radius": radius
+            }
+        }
+    }
+
+    if included_types:
+        request_body["includedTypes"] = included_types
+    if excluded_types:
+        request_body["excludeTypes"] = excluded_types
+
+    resp = requests.post(URL, headers=headers, json=request_body)
+    resp.raise_for_status()
+
+    places = resp.json()['places']
+    places = list(filter(lambda p: p["rating"] > min_rating, places))
+
+    return places
+
+
+def main():
+    # TODO: Figure out the required mask
+    field_mask = [
+        "places.id",
+        "places.displayName",
+        "places.location",
+        "places.rating",
+        "places.formattedAddress",
+    ]
+    places = fetch_places(center=YEREVAN_CENTER, radius=RADIUS, field_mask=field_mask)
+
+    with open('data.json', 'w', encoding='utf-8') as f:
+        json.dump(places, f, ensure_ascii=False, indent=4)
+
+
+if __name__ == '__main__':
+    main()

--- a/components/backend/research/data-sources/google-places/data.json
+++ b/components/backend/research/data-sources/google-places/data.json
@@ -1,0 +1,132 @@
+[
+    {
+        "id": "ChIJkZZJKPq8akARdGwWJ9EU3is",
+        "formattedAddress": "5GH7+33C, Yerevan, Armenia",
+        "location": {
+            "latitude": 40.1776945,
+            "longitude": 44.5126511
+        },
+        "rating": 4.8,
+        "displayName": {
+            "text": "Republic Square",
+            "languageCode": "en"
+        }
+    },
+    {
+        "id": "ChIJE57wmJW9akARjAdWaJwYw5Y",
+        "formattedAddress": "5, 1 Hyusisayin poghota, Yerevan 0001, Armenia",
+        "location": {
+            "latitude": 40.1811183,
+            "longitude": 44.5152601
+        },
+        "rating": 4.7,
+        "displayName": {
+            "text": "L'ÉTÉ Cafe & Veranda",
+            "languageCode": "en"
+        }
+    },
+    {
+        "id": "ChIJoTKy_fu8akARn1RPH3RYlLI",
+        "formattedAddress": "5 Amiryan St, Yerevan 0010, Armenia",
+        "location": {
+            "latitude": 40.179007,
+            "longitude": 44.510079999999995
+        },
+        "rating": 4.6,
+        "displayName": {
+            "text": "Tavern Yerevan",
+            "languageCode": "en"
+        }
+    },
+    {
+        "id": "ChIJh6hJZfm8akAR30UEhfgdhzI",
+        "formattedAddress": "1 Amiryan St, Yerevan 0010, Armenia",
+        "location": {
+            "latitude": 40.1783632,
+            "longitude": 44.511065099999996
+        },
+        "rating": 4.5,
+        "displayName": {
+            "text": "Armenia Marriott Hotel Yerevan",
+            "languageCode": "en"
+        }
+    },
+    {
+        "id": "ChIJPyXRY_m8akAREOAnuQcdc0U",
+        "formattedAddress": "1 Amiryan St, Yerevan 0010, Armenia",
+        "location": {
+            "latitude": 40.178441199999995,
+            "longitude": 44.5110096
+        },
+        "rating": 4.6,
+        "displayName": {
+            "text": "Sherep Restaurant",
+            "languageCode": "en"
+        }
+    },
+    {
+        "id": "ChIJeTV6yfm8akARX2VtA3GXgmw",
+        "formattedAddress": "10 Vazgen Sargsyan St, Yerevan 0010, Armenia",
+        "location": {
+            "latitude": 40.1763311,
+            "longitude": 44.511191499999995
+        },
+        "rating": 4.6,
+        "displayName": {
+            "text": "Piazza Grande",
+            "languageCode": "en"
+        }
+    },
+    {
+        "id": "ChIJJ2oATfu8akARgn7mNF_M4f8",
+        "formattedAddress": "5/1 Hyusisayin poghota, Yerevan 0001, Armenia",
+        "location": {
+            "latitude": 40.1816101,
+            "longitude": 44.514907099999995
+        },
+        "rating": 4.5,
+        "displayName": {
+            "text": "ibis Yerevan Center",
+            "languageCode": "en"
+        }
+    },
+    {
+        "id": "ChIJbfffStK9akARqNmF672UbEw",
+        "formattedAddress": "15 Pavstos Buzand St, Yerevan, Armenia",
+        "location": {
+            "latitude": 40.1798053,
+            "longitude": 44.511722
+        },
+        "rating": 4.5,
+        "displayName": {
+            "text": "Ramada Hotel & Suites by Wyndham Yerevan",
+            "languageCode": "en"
+        }
+    },
+    {
+        "id": "ChIJxx2CdPe8akARG77Adf4hMBY",
+        "formattedAddress": "10 Tigran Mets Ave, Yerevan 0010, Armenia",
+        "location": {
+            "latitude": 40.174483599999995,
+            "longitude": 44.5136209
+        },
+        "rating": 4.4,
+        "displayName": {
+            "text": "Yerevan City",
+            "languageCode": "en"
+        }
+    },
+    {
+        "id": "ChIJxQ-sTfq8akARpueMB-KMHPE",
+        "formattedAddress": "Հանրապետության հրապարակ 4, Yerevan 375010, Armenia",
+        "location": {
+            "latitude": 40.1786768,
+            "longitude": 44.5141239
+        },
+        "rating": 4.4,
+        "displayName": {
+            "text": "History Museum of Armenia",
+            "languageCode": "en"
+        }
+    }
+]


### PR DESCRIPTION
This PR contains a runnable script that fetches POIs from the Google Places API, as well as a JSON file that represents the result of running the script. To run the script, an `API_KEY` is required.

@ArtiomVlasov We need to figure out what data about the places we need.

Closes #11 