### PR TITLE
Add backend flow overview schema

### DIFF
--- a/components/backend/docs/schemas/flow_overview.mmd
+++ b/components/backend/docs/schemas/flow_overview.mmd
@@ -1,0 +1,12 @@
+flowchart TD
+    subgraph Backend
+        PromptParserService["PromptParserService (LLM)"]
+        PlacesRecommendationService["PlacesRecommendationService (e.g. Scoring)"]
+        ItineraryBuilderService["ItineraryBuilderService"]
+    end
+
+    User --> FrontEnd -->|Prompt| PromptParserService
+    PromptParserService -->|Filled Itinerary Questionary| PlacesRecommendationService
+    PlacesRecommendationService -->|Selected places| ItineraryBuilderService
+    PlacesRecommendationService -->|Selected places| FrontEnd
+    ItineraryBuilderService -->|Built Pathway| FrontEnd


### PR DESCRIPTION
The schema looks like this:
```mermaid
flowchart TD
    subgraph Backend
        PromptParserService["PromptParserService (LLM)"]
        PlacesRecommendationService["PlacesRecommendationService (e.g. Scoring)"]
        ItineraryBuilderService["ItineraryBuilderService"]
    end

    User --> FrontEnd -->|Prompt| PromptParserService
    PromptParserService -->|Filled Itinerary Questionary| PlacesRecommendationService
    PlacesRecommendationService -->|Selected places| ItineraryBuilderService
    PlacesRecommendationService -->|Selected places| FrontEnd
    ItineraryBuilderService -->|Built Pathway| FrontEnd
```